### PR TITLE
Adicionando query filters

### DIFF
--- a/src/controllers/HorarioController.js
+++ b/src/controllers/HorarioController.js
@@ -1,37 +1,96 @@
-import loadHorarios from '../utils/data';
+import loadHorarios from "../utils/data";
 
 let horarios;
-loadHorarios().then(response => horarios = response);
+loadHorarios().then(response => (horarios = response));
+
+function containsQuery(query) {
+  return query !== undefined && query !== null;
+}
+
+function applyQueryFilters(queries) {
+  let horariosAndQueryFilters = [...horarios];
+
+  if (containsQuery(queries.professor)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.professor === queries.professor
+    );
+  }
+
+  if (containsQuery(queries.categoria)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.categoria === queries.categoria
+    );
+  }
+
+  if (containsQuery(queries.turma)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.turma === queries.turma
+    );
+  }
+
+  if (containsQuery(queries.disciplina)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.disciplina === queries.disciplina
+    );
+  }
+
+  if (containsQuery(queries.sala)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.sala === queries.sala
+    );
+  }
+
+  if (containsQuery(queries.periodo_ppc_antigo)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.periodo_ppc_antigo === queries.periodo_ppc_antigo
+    );
+  }
+
+  if (containsQuery(queries.periodo_ppc_novo)) {
+    horariosAndQueryFilters = horariosAndQueryFilters.filter(
+      horario => horario.periodo_ppc_novo === queries.periodo_ppc_novo
+    );
+  }
+
+  return horariosAndQueryFilters;
+}
 
 module.exports = {
-    indexAll(req, res) {
-        res.send(horarios);
-    },
+  indexAll(req, res) {
+    const horariosAndQueryFilters = applyQueryFilters(req.query);
 
-    indexByDay(req, res) {
-        const dias = ['segunda', 'terca', 'quarta', 'quinta', 'sexta'];
+    res.send(horariosAndQueryFilters);
+  },
 
-        const dia = req.params.dia;
+  indexByDay(req, res) {
+    const dias = ["segunda", "terca", "quarta", "quinta", "sexta"];
 
-        if (dia && dias.includes(dia)) {
-            res.send(horarios.filter(horario => horario.horario.dia === dia));
-        } else {
-            res.status(404).send({ error: 'Error' });
-        }
-    },
+    const dia = req.params.dia;
 
-    indexByDayAndHour(req, res) {
-        const dias = ['segunda', 'terca', 'quarta', 'quinta', 'sexta'];
-        const horas = [8, 10, 14, 16, 18];
-        
-        const dia = req.params.dia;
-        const hora = parseInt(req.params.hora);
-
-        if ((dia && dias.includes(dia)) && (hora && horas.includes(hora))) {
-            res.send(horarios.filter(horario => (horario.horario.dia === dia) && (parseInt(horario.horario.hora) === hora)));
-        } else {
-            res.status(404).send({ error: 'Error' });
-        }
-
+    if (dia && dias.includes(dia)) {
+      res.send(horarios.filter(horario => horario.horario.dia === dia));
+    } else {
+      res.status(404).send({ error: "Error" });
     }
+  },
+
+  indexByDayAndHour(req, res) {
+    const dias = ["segunda", "terca", "quarta", "quinta", "sexta"];
+    const horas = [8, 10, 14, 16, 18];
+
+    const dia = req.params.dia;
+    const hora = parseInt(req.params.hora);
+
+    if (dia && dias.includes(dia) && (hora && horas.includes(hora))) {
+      res.send(
+        horarios.filter(
+          horario =>
+            horario.horario.dia === dia &&
+            parseInt(horario.horario.hora) === hora
+        )
+      );
+    } else {
+      res.status(404).send({ error: "Error" });
+    }
+  }
 };


### PR DESCRIPTION
Estava consultando uns horários e a API foi bem útil pra mim. Adicionei a opção de filtrar os resultados usando _querystrings_.

O seguinte request `http://localhost:3000/horarios?professor=thiago&periodo_ppc_novo=2` retorna resultados filtrados pelos critérios escolhidos:

```
[
  {
    "sala": "pre",
    "disciplina": "fmcc2",
    "turma": "t2",
    "professor": "thiago",
    "categoria": "obrigatoria",
    "periodo_ppc_antigo": "-",
    "periodo_ppc_novo": "2",
    "horario": { "dia": "quinta", "hora": "08" }
  },
  {
    "sala": "pre",
    "disciplina": "fmcc2",
    "turma": "t2",
    "professor": "thiago",
    "categoria": "obrigatoria",
    "periodo_ppc_antigo": "-",
    "periodo_ppc_novo": "2",
    "horario": { "dia": "segunda", "hora": "10" }
  }
]
```

É possível filtrar pelos seguintes critérios  `sala`,  `disciplina`, `turma`,`professor`,`categoria`,`periodo_ppc_antigo` e `periodo_ppc_novo`.

Nenhuma validação é feita.